### PR TITLE
"Reload Previous Build" button & CVR World requirement.

### DIFF
--- a/Unity/Assets/Moyuer/Script/CVRLocalTest/LocalAvatarTest.cs
+++ b/Unity/Assets/Moyuer/Script/CVRLocalTest/LocalAvatarTest.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+#if UNITY_EDITOR
 using ABI.CCK.Components;
 using System.IO;
 using System.Collections;
@@ -6,21 +6,119 @@ using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 using static MoyuerLocalTest.LocalTestUtils;
+
 namespace MoyuerLocalTest
 {
 
     public class CVRLocalAvatarTest : EditorWindow
     {
+
+        public const string BUILDPATH = "Build/LocalAvatarTest/";
+        public const string PREFABPATH = "Assets/temp.prefab";
+        public const string TEMPNAME = "temp";
+
         private Vector2 mainScrollPos;
         private CVRAvatar avatar;
+
         [MenuItem("Moyuer/CVR_LocalTest/Avatar", false, 0)]
         private static void ShowWindow()
         {
-            GetWindow<CVRLocalAvatarTest>();
+            GetWindow<CVRLocalAvatarTest>("LocalAvatarTest");
         }
+
         private void OnGUI()
         {
             mainScrollPos = GUILayout.BeginScrollView(mainScrollPos);
+
+            ModByMoyuer();
+
+            GUILayout.Space(10);
+            EditorGUIUtility.labelWidth = 80f;
+            avatar = (CVRAvatar)EditorGUILayout.ObjectField("Avatar", avatar, typeof(CVRAvatar), true);
+            GUILayout.Space(10);
+
+            if (avatar == null) 
+                EditorGUILayout.HelpBox("Please select your Avatar.", MessageType.Warning);
+
+            using (new EditorGUI.DisabledScope(avatar == null))
+                if (GUILayout.Button("Build Test Avatar")) 
+                    Build(avatar.gameObject);
+
+            if (GUILayout.Button("Reload Previous Build"))
+                Reload();
+
+            GUILayout.EndScrollView();
+        }
+
+        private static void Build(GameObject avatar)
+        {
+            SaveTempPrefab(avatar);
+
+            CreateBuildDirectory();
+
+            RemovePreviousBuild();
+
+            BuildNewAvatar();
+
+            SendUDPAvatar();
+            
+            File.Delete(PREFABPATH);
+        }
+        private static void Reload()
+        {
+            var fileName = BUILDPATH + TEMPNAME;
+            if (File.Exists(fileName))
+            {
+                SendUDPAvatar();
+            }
+            else
+            {
+                EditorUtility.DisplayDialog("Error", "No previous avatar build found!", "OK");
+            }
+        }
+
+
+        private static void SaveTempPrefab(GameObject avatar)
+        {
+            avatar.SetActive(true);
+            if (PrefabUtility.SaveAsPrefabAsset(avatar, PREFABPATH) == null)
+            {
+                EditorUtility.DisplayDialog("Error", "An error occurred while saving prefab. Please check the console log.", "OK");
+                return;
+            }
+        }
+        private static void BuildNewAvatar()
+        {
+            var builds = new List<AssetBundleBuild>();
+            var build = new AssetBundleBuild();
+            build.assetBundleName = TEMPNAME;
+            build.assetNames = new string[] { PREFABPATH };
+            builds.Add(build);
+            if (BuildPipeline.BuildAssetBundles(BUILDPATH, builds.ToArray(), BuildAssetBundleOptions.None, BuildTarget.StandaloneWindows) == null)
+            {
+                EditorUtility.DisplayDialog("Error", "An error occurred while building asset bundle. Please check the console log.", "OK");
+                return;
+            }
+        }
+        private static void CreateBuildDirectory()
+        {
+            if (Directory.Exists(BUILDPATH)) Directory.Delete(BUILDPATH, true);
+            Directory.CreateDirectory(BUILDPATH);
+        }
+        private static void RemovePreviousBuild()
+        {
+            var fileName = BUILDPATH + TEMPNAME;
+            if (File.Exists(fileName)) File.Delete(fileName);
+        }
+        private static void SendUDPAvatar()
+        {
+            var m_Path = (Path.GetDirectoryName(Application.dataPath) + "/" + BUILDPATH).Replace("\\", "/");
+            SendUDPPacket("{\"type\":\"change_local_avatar\",\"path\":\"" + (m_Path + TEMPNAME) + "\"}");
+            EditorUtility.DisplayDialog("LocalAvatarTest", "Built local avatar successfully. Please go to the game to check the effect.", "OK");
+        }
+
+        private static void ModByMoyuer()
+        {
             GUILayout.Space(10);
             GUI.skin.label.fontSize = 24;
             GUI.skin.label.alignment = TextAnchor.MiddleCenter;
@@ -32,47 +130,6 @@ namespace MoyuerLocalTest
             GUI.skin.label.alignment = TextAnchor.MiddleCenter;
             GUILayout.Label("by: 如梦(Moyuer)");
             GUILayout.Space(10);
-            GUILayout.Space(10);
-            avatar = (CVRAvatar)EditorGUILayout.ObjectField("Avatar", avatar, typeof(CVRAvatar), true);
-            GUILayout.Space(10);
-            if (avatar == null) EditorGUILayout.HelpBox("Please select your Avatar.", MessageType.Warning);
-            if (GUILayout.Button("Start Test") && avatar != null)
-            {
-                Fix(avatar.gameObject);
-            }
-            GUILayout.EndScrollView();
-        }
-
-        private static void Fix(GameObject avatar)
-        {
-            avatar.SetActive(true);
-            var prefabPath = "Assets/temp.prefab";
-            if (PrefabUtility.SaveAsPrefabAsset(avatar, prefabPath) == null)
-            {
-                EditorUtility.DisplayDialog("Error", "An error occurred, please check the Console log", "OK");
-                return;
-            }
-            var path = Application.dataPath.Replace("\\", "/");
-            if (path.Contains("/")) path = path.Substring(0, path.LastIndexOf("/"));
-            path += "/Build/";
-            if (Directory.Exists(path)) Directory.Delete(path, true);
-            Directory.CreateDirectory(path);
-            var fileName = path + "temp";
-            if (File.Exists(fileName)) File.Delete(fileName);
-
-            var builds = new List<AssetBundleBuild>();
-            var build = new AssetBundleBuild();
-            build.assetBundleName = "temp";
-            build.assetNames = new string[] { prefabPath };
-            builds.Add(build);
-            if (BuildPipeline.BuildAssetBundles(path, builds.ToArray(), BuildAssetBundleOptions.None, BuildTarget.StandaloneWindows) == null)
-            {
-                EditorUtility.DisplayDialog("Error", "Built local avatar failed, please check the console log", "OK");
-                return;
-            }
-            SendUDPPacket("{\"type\":\"change_local_avatar\",\"path\":\"" + (path + "temp") + "\"}");
-            EditorUtility.DisplayDialog("Tip", "Built local avatar successfully, please go to the game to check the effect", "OK");
-            File.Delete(prefabPath);
         }
     }
 }


### PR DESCRIPTION
Added a "Reload Previous Build" button for LocalAvatarTest. Sends UDP of already-built avatar if available.
![image](https://user-images.githubusercontent.com/37721153/183320408-0132d432-0038-4475-8ff1-0849351634f6.png)


Added requirement to LocalWorldTest to have one CVR World component in the scene. 
*i kept accidentally building my avatar scene into a world*

Reformatted code to be easier to edit. Cleaned up strings to be easier to understand.

Builds now are saved in "Build/LocalAvatarTest/" & "Build/LocalWorldTest/".

**NOTE**
This probably broke error-catching. The script may still finish running when encountering an error and pressing OK.